### PR TITLE
Add a pytest suite + CI for the settings service

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Make the repo root importable so `import gitnoc...` works without an install.
+pythonpath = .
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development / test dependencies.
+# The settings-service test suite is intentionally decoupled from the runtime
+# stack (Flask, redis, git-pandas) via stubs in tests/conftest.py, so pytest is
+# all that's needed to run it.
+pytest>=7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Shared pytest fixtures for the gitnoc test suite.
+
+The settings service (``gitnoc.services.settings``) imports ``gitnoc.app`` and
+``gitpandas`` at module load time, which would otherwise drag in Flask, redis
+and git-pandas just to exercise some pure file-backed JSON logic.  We stub those
+modules in ``sys.modules`` *before* importing the service so the tests stay fast
+and dependency-free.
+"""
+import json
+import sys
+import types
+
+import pytest
+
+# --- Stub the heavy/optional imports pulled in by the settings module --------
+if "gitpandas" not in sys.modules:
+    _gitpandas_stub = types.ModuleType("gitpandas")
+    _gitpandas_stub.ProjectDirectory = object  # only referenced, never called here
+    sys.modules["gitpandas"] = _gitpandas_stub
+
+if "gitnoc.app" not in sys.modules:
+    _app_stub = types.ModuleType("gitnoc.app")
+    _app_stub.gp_cache = None
+    sys.modules["gitnoc.app"] = _app_stub
+
+# Import after stubbing so the real Flask/redis/git-pandas stack is never loaded.
+from gitnoc.services import settings as settings_service  # noqa: E402
+
+
+class SettingsEnv:
+    """Helper handed to tests for reading/writing the temp ``settings.json``."""
+
+    def __init__(self, module, path):
+        self.module = module
+        self.path = path
+
+    def write(self, data):
+        self.path.write_text(json.dumps(data))
+
+    def read(self):
+        return json.loads(self.path.read_text())
+
+
+@pytest.fixture
+def settings_env(tmp_path, monkeypatch):
+    """Point the settings module at a throwaway ``settings.json``.
+
+    The module derives its config path from its own ``__file__``::
+
+        bp = dirname(dirname(abspath(__file__)))
+        path = bp + os.sep + 'settings.json'
+
+    so we monkeypatch ``__file__`` to a fake location two directories deep under
+    ``tmp_path``.  Every read/write then lands on the temp file and the repo's
+    real ``gitnoc/settings.json`` is never touched.
+    """
+    pkg_dir = tmp_path / "gitnoc"
+    fake_file = pkg_dir / "services" / "settings.py"
+    fake_file.parent.mkdir(parents=True)
+    monkeypatch.setattr(settings_service, "__file__", str(fake_file))
+    return SettingsEnv(settings_service, pkg_dir / "settings.json")

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -1,0 +1,125 @@
+"""Tests for ``gitnoc.services.settings``.
+
+These exercise the file-backed JSON profile logic in isolation.  The
+``settings_env`` fixture (see ``conftest.py``) redirects the module at a
+temporary ``settings.json`` so the repo's real config is never read or written.
+"""
+
+
+def test_get_settings_missing_file_returns_empty_default(settings_env):
+    # No settings.json on disk at all -> safe empty default, not an exception.
+    assert not settings_env.path.exists()
+    assert settings_env.module.get_settings() == {}
+
+
+def test_get_settings_empty_file_returns_empty_default(settings_env):
+    # An empty/malformed file is swallowed and yields the empty default.
+    settings_env.path.write_text("")
+    assert settings_env.module.get_settings() == {}
+
+
+def test_get_settings_returns_current_profile(settings_env):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": False},
+        {"profile_name": "b", "current_profile": True},
+    ])
+    assert settings_env.module.get_settings()["profile_name"] == "b"
+
+
+def test_get_settings_no_current_profile_returns_empty(settings_env):
+    settings_env.write([{"profile_name": "a", "current_profile": False}])
+    assert settings_env.module.get_settings() == {}
+
+
+def test_create_profile_appends(settings_env):
+    settings_env.write([])
+
+    assert settings_env.module.create_profile("first") is True
+    assert settings_env.module.create_profile("second") is True
+
+    configs = settings_env.read()
+    assert [c["profile_name"] for c in configs] == ["first", "second"]
+    # New profiles are seeded with the documented defaults.
+    for c in configs:
+        assert c["current_profile"] is False
+        assert c["extensions"] is None
+        assert c["ignore_dir"] is None
+        assert c["project_dir"] is None
+
+
+def test_change_profile_sets_exactly_one_current(settings_env):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": True},
+        {"profile_name": "b", "current_profile": False},
+        {"profile_name": "c", "current_profile": False},
+    ])
+
+    assert settings_env.module.change_profile("c") is True
+
+    configs = settings_env.read()
+    current = [c["profile_name"] for c in configs if c["current_profile"]]
+    assert current == ["c"]
+    # Every other profile is explicitly cleared.
+    assert all(c["current_profile"] is False for c in configs if c["profile_name"] != "c")
+
+
+def test_update_profile_writes_only_to_current(settings_env):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": False,
+         "project_dir": None, "extensions": None, "ignore_dir": None},
+        {"profile_name": "b", "current_profile": True,
+         "project_dir": None, "extensions": None, "ignore_dir": None},
+    ])
+
+    assert settings_env.module.update_profile(
+        project_dir="/tmp/code", extensions=["py"], ignore_dir=["vendor"]
+    ) is True
+
+    by_name = {c["profile_name"]: c for c in settings_env.read()}
+    assert by_name["b"]["project_dir"] == "/tmp/code"
+    assert by_name["b"]["extensions"] == ["py"]
+    assert by_name["b"]["ignore_dir"] == ["vendor"]
+    # The non-current profile is left untouched.
+    assert by_name["a"]["project_dir"] is None
+    assert by_name["a"]["extensions"] is None
+    assert by_name["a"]["ignore_dir"] is None
+
+
+def test_get_profiles_returns_name_choice_tuples(settings_env):
+    settings_env.write([
+        {"profile_name": "alpha", "current_profile": True},
+        {"profile_name": "beta", "current_profile": False},
+    ])
+    assert settings_env.module.get_profiles() == [("alpha", "alpha"), ("beta", "beta")]
+
+
+def test_get_profiles_missing_file_returns_empty_list(settings_env):
+    assert settings_env.module.get_profiles() == []
+
+
+def test_get_file_prefix_slugifies_spaces(settings_env):
+    settings_env.write([{"profile_name": "My Project Name", "current_profile": True}])
+    assert settings_env.module.get_file_prefix() == "My_Project_Name_"
+
+
+def test_get_file_prefix_no_current_profile_returns_empty(settings_env):
+    settings_env.write([{"profile_name": "My Project", "current_profile": False}])
+    assert settings_env.module.get_file_prefix() == ""
+
+
+def test_get_file_prefix_missing_file_returns_empty(settings_env):
+    assert settings_env.module.get_file_prefix() == ""
+
+
+def test_ignore_file_appends_to_current_profile(settings_env):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": False, "ignore_dir": []},
+        {"profile_name": "b", "current_profile": True, "ignore_dir": []},
+    ])
+
+    assert settings_env.module.ignore_file("src-vendor-lib") is True
+
+    by_name = {c["profile_name"]: c for c in settings_env.read()}
+    # Dashes in the encoded path are turned back into path separators.
+    assert by_name["b"]["ignore_dir"] == ["src/vendor/lib"]
+    assert by_name["a"]["ignore_dir"] == []


### PR DESCRIPTION
Closes #5

## What changed
Adds the repo's first automated tests and CI, scoped to `gitnoc/services/settings.py` (the file-backed JSON profile/state logic) as proposed in the issue. No production code behavior was changed.

- **`tests/test_settings_service.py`** — 13 cases covering:
  - `create_profile` appends a profile (seeded with the documented `extensions`/`ignore_dir`/`project_dir = None` defaults).
  - `change_profile` makes exactly one profile `current_profile=True` and clears the rest.
  - `update_profile` writes `project_dir`/`extensions`/`ignore_dir` only to the current profile, leaving others untouched.
  - `ignore_file` appends to the current profile's `ignore_dir`, decoding `-` back to `/`.
  - `get_profiles` returns `(name, name)` choice tuples.
  - `get_file_prefix` slugifies spaces to underscores (`"My Project Name"` → `"My_Project_Name_"`).
  - `get_settings` returns the current profile, and falls back to `{}` on a missing/empty file.
- **`tests/conftest.py`** — a `settings_env` fixture that redirects the module at a temporary `settings.json` (via `tmp_path` + a monkeypatched module `__file__`, since the module derives its path from `dirname(dirname(abspath(__file__)))`). The repo's real `gitnoc/settings.json` is never read or written.
  - It also stubs `gitnoc.app` and `gitpandas` in `sys.modules` before import. The settings module does `from gitnoc.app import gp_cache` at load time, which would otherwise pull in Flask/redis/git-pandas just to test pure JSON logic; stubbing keeps the suite fast and dependency-free.
- **`.github/workflows/tests.yml`** — installs `requirements-dev.txt` and runs `pytest` on push and PR across Python 3.9 / 3.11 / 3.12.
- **`pytest.ini`** — `pythonpath = .` so `import gitnoc...` works without an install; `testpaths = tests`.
- **`requirements-dev.txt`** — pins `pytest>=7.0`.

## Notes
- The suite is intentionally decoupled from the runtime stack via the conftest stubs, so CI needs only `pytest` (no redis/git-pandas) and stays green and fast.
- Issue #3 (safe default for `get_settings`) is not merged; the existing behavior already returns `{}` on a missing/empty file, which the tests assert. If #3 changes that default, update the two `get_settings` empty-default cases accordingly.

## Verification
Ran locally in a clean venv with only the dev deps installed:

```
$ python3 -m venv /tmp/gitnoc-venv
$ /tmp/gitnoc-venv/bin/pip install -r requirements-dev.txt
$ /tmp/gitnoc-venv/bin/pytest -q
.............                                                            [100%]
13 passed in 0.05s
```

Confirmed no `gitnoc/settings.json` exists in the working tree before or after the run (tests use only the temp file).