### PR TITLE
Fix copy-paste bug in admin settings(): guard list-join on the correct field

### DIFF
--- a/gitnoc/views/admin.py
+++ b/gitnoc/views/admin.py
@@ -37,7 +37,7 @@ def settings():
         pdv = ''
 
     if extensions is not None:
-        if isinstance(project_dir, list):
+        if isinstance(extensions, list):
             ext = ','.join(extensions)
         else:
             ext = extensions
@@ -45,7 +45,7 @@ def settings():
         ext = ''
 
     if ignore_dir is not None:
-        if isinstance(project_dir, list):
+        if isinstance(ignore_dir, list):
             ign = ','.join(ignore_dir)
         else:
             ign = ignore_dir


### PR DESCRIPTION
Closes #4

## Summary
Fixes a copy-paste bug in `gitnoc/views/admin.py` `settings()`. The `extensions` and `ignore_dir` formatting branches both gated their list-join on `isinstance(project_dir, list)` instead of the field actually being formatted. When `extensions`/`ignore_dir` is a list but `project_dir` is a plain string, the raw Python list (e.g. `['py', 'js']`) was passed to the template as `extensions_values`/`ignore_dir_values` instead of the joined string `py,js`, producing garbled values in the settings form's tagsinput fields.

## Changes
- `gitnoc/views/admin.py:40` — guard now tests `isinstance(extensions, list)`.
- `gitnoc/views/admin.py:48` — guard now tests `isinstance(ignore_dir, list)`.

The `project_dir` branch (line ~32) was already correct and is unchanged. No behavioral change when all three fields share the same type.

## Verification
- `python3 -m py_compile gitnoc/views/admin.py` — passes (no syntax errors).
- Reviewed the diff against the issue's acceptance checklist: both guards now reference their own variable; a profile with list-valued `extensions`/`ignore_dir` and a string `project_dir` will render comma-joined strings rather than Python list reprs.

No test suite exists in this branch, so no tests were added; the change is a focused two-line correction as the issue specifies.
