### PR TITLE
Prevent crashes on fresh install / new profile (safe settings defaults)

### DIFF
--- a/gitnoc/services/settings.py
+++ b/gitnoc/services/settings.py
@@ -6,16 +6,48 @@ import os
 __author__ = 'willmcginnis'
 
 
+def default_settings():
+    """Safe defaults so the app degrades gracefully when no profile is configured.
+
+    Used when ``settings.json`` is missing/unreadable or no profile is marked
+    current. Returning these keys (rather than ``{}``) keeps ``render_wrapper``
+    and the service modules from crashing on a fresh install.
+    """
+    return {
+        'profile_name': 'default',
+        'project_dir': os.getcwd(),
+        'extensions': [],
+        'ignore_dir': [],
+    }
+
+
+def normalize_settings(config):
+    """Fill missing keys and coerce ``None`` extensions/ignore_dir to ``[]``.
+
+    New profiles are seeded with ``None`` for these fields (see
+    ``create_profile``), which breaks the glob comprehensions in the service
+    modules. Normalizing here means callers never receive ``None``.
+    """
+    settings = default_settings()
+    settings.update({k: v for k, v in config.items() if v is not None})
+    if not settings.get('project_dir'):
+        settings['project_dir'] = os.getcwd()
+    for key in ('extensions', 'ignore_dir'):
+        if settings.get(key) is None:
+            settings[key] = []
+    return settings
+
+
 def get_settings():
     try:
         bp = str(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         configs = json.load(open(bp + os.sep + 'settings.json', 'r'))
         for config in configs:
             if config.get('current_profile', False):
-                return config
-        return {}
+                return normalize_settings(config)
+        return default_settings()
     except:
-        return {}
+        return default_settings()
 
 
 def get_profiles():


### PR DESCRIPTION
Closes #3

## Summary
GitNOC 500'd out of the box and right after creating a new profile. Two root causes:

1. **No `settings.json` ⇒ `KeyError: 'profile_name'`** on every page. `get_settings()` returned `{}`, and `render_wrapper` does `get_settings()['profile_name']` (`gitnoc/utils.py:8`).
2. **New profiles seed `extensions`/`ignore_dir` = `None` ⇒ `TypeError: 'NoneType' object is not iterable`** in the glob comprehensions used by the risk/metrics/blame/punchcard endpoints.

## What changed
All defensive handling is centralized in `gitnoc/services/settings.py` (the single chokepoint every page and service goes through):

- Added `default_settings()` returning `{'profile_name': 'default', 'project_dir': os.getcwd(), 'extensions': [], 'ignore_dir': []}`.
- Added `normalize_settings()` which fills missing keys and coerces `None` `extensions`/`ignore_dir`/`project_dir` to safe values.
- `get_settings()` now returns `default_settings()` when `settings.json` is missing/unreadable or no profile is current, and runs the matched profile through `normalize_settings()` otherwise.

Because every service module and view obtains its config via `get_settings()`, no per-call-site edits were needed — the glob comprehensions can never receive `None` again. Behavior for a fully-populated profile is byte-for-byte unchanged.

## Verification
- `python3 -m py_compile` on all touched modules → OK.
- Functional test (stubbing `gitnoc.app`/`gitpandas` per the import coupling) covering three cases, all passing:
  - **No `settings.json`** → `get_settings()` returns `profile_name='default'`, `extensions=[]`, `ignore_dir=[]`, non-empty `project_dir` (fixes the `render_wrapper` KeyError → `GET /` renders).
  - **Profile with `None` `extensions`/`ignore_dir`/`project_dir`** → coerced to `[]`/`[]`/cwd; the `['*/%s/*' % x ...]` and `['*.%s' % x ...]` comprehensions run without `TypeError`.
  - **Fully-populated profile** → values returned verbatim, no change.

(The repo's pytest suite/CI does not exist on `master`, so `py_compile` + the standalone functional script are the available checks on this branch.)

## Acceptance
- [x] No `settings.json` ⇒ `GET /` no longer 500s (renders with empty defaults).
- [x] Profile with `None` `extensions`/`ignore_dir` ⇒ risk / file_change_rates / `/` / punchcard / blame endpoints no longer raise `TypeError`.
- [x] `get_settings()` never returns a dict lacking `profile_name`.
- [x] No behavior change for an existing, fully-populated profile.
