### PR TITLE
ci: efficiency + hygiene tuning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,12 @@ name: tests
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -19,6 +24,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dev dependencies
         run: |


### PR DESCRIPTION
Efficiency + hygiene tuning for the tests workflow:

- Add `concurrency: cancel-in-progress` to cancel superseded runs on the same ref
- Scope `push` to `[master]` (was firing on every branch alongside the PR run)
- Cache pip deps (`cache: 'pip'` on `actions/setup-python`)
