### PR TITLE
Make the analyzed branch configurable per profile

### DIFF
--- a/gitnoc/forms/public.py
+++ b/gitnoc/forms/public.py
@@ -23,6 +23,7 @@ class SettingsForm(Form):
     project_directory = StringField('Project Directory (absolute path)', validators=[DataRequired()])
     extensions = StringField('Extensions to Report On')
     ignore_dir = StringField('Directories to Ignore')
+    branch = StringField('Branch to Analyze')
 
     def __init__(self, *args, **kwargs):
         super(SettingsForm, self).__init__(*args, **kwargs)
@@ -46,5 +47,7 @@ class SettingsForm(Form):
             self.ignore_dir.data = [str(x).strip() for x in self.ignore_dir.data.split(',')]
             if self.ignore_dir.data == ['']:
                 self.ignore_dir.data = None
+
+        self.branch.data = (self.branch.data or '').strip() or 'master'
 
         return True

--- a/gitnoc/services/cumulative_blame.py
+++ b/gitnoc/services/cumulative_blame.py
@@ -12,12 +12,10 @@ def cumulative_blame(by, file_stub):
     project_dir = settings.get('project_dir', os.getcwd())
     extensions = settings.get('extensions', None)
     ignore_dir = settings.get('ignore_dir', None)
+    branch = settings.get('branch', 'master')
 
     repo = ProjectDirectory(working_dir=project_dir, cache_backend=gp_cache)
-    print(extensions)
-    print(ignore_dir)
-    print(by)
-    cb = repo.cumulative_blame(branch='master', ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], by=by, skip=3, limit=300)
+    cb = repo.cumulative_blame(branch=branch, ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], by=by, skip=3, limit=300)
     cb = cb[~cb.index.duplicated()]
     t = json.loads(cb.to_json(orient='columns'))
 

--- a/gitnoc/services/metrics.py
+++ b/gitnoc/services/metrics.py
@@ -14,12 +14,12 @@ def week_leader_board(n=5):
     project_dir = settings.get('project_dir', os.getcwd())
     extensions = settings.get('extensions', None)
     ignore_dir = settings.get('ignore_dir', None)
+    branch = settings.get('branch', 'master')
 
     repo = ProjectDirectory(working_dir=project_dir, cache_backend=gp_cache)
-    ch = repo.commit_history(branch='master', ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], limit=None, days=21)
+    ch = repo.commit_history(branch=branch, ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], limit=None, days=21)
 
     metric = 'net'
-    print(ch)
     leader_board = {
         'top_committers': [],
         'top_repositories': [],
@@ -39,7 +39,7 @@ def week_leader_board(n=5):
     if extensions is not None:
         ext_ranks = []
         for ext in extensions:
-            ch = repo.commit_history(branch='master', ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], days=21)
+            ch = repo.commit_history(branch=branch, ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], days=21)
             ext_ranks.append((ch[metric].sum(), ext))
         ext_ranks = sorted(ext_ranks, key=lambda x: x[0], reverse=True)[:n]
         leader_board['top_extensions'] = [{'label': x[1], 'net': int(x[0]), 'rank': idx + 1} for idx, x in enumerate(ext_ranks)]
@@ -48,10 +48,10 @@ def week_leader_board(n=5):
 
 
 @cache.cached(timeout=600, key_prefix='metrics_punchcard_')
-def get_punchcard(project_dir, extensions, ignore_dir):
+def get_punchcard(project_dir, extensions, ignore_dir, branch='master'):
     repo = ProjectDirectory(working_dir=project_dir, cache_backend=gp_cache)
     pc = repo.punchcard(
-        branch='master',
+        branch=branch,
         ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir],
         include_globs=['*.%s' % (x, ) for x in extensions]
     )

--- a/gitnoc/services/settings.py
+++ b/gitnoc/services/settings.py
@@ -18,6 +18,7 @@ def default_settings():
         'project_dir': os.getcwd(),
         'extensions': [],
         'ignore_dir': [],
+        'branch': 'master',
     }
 
 
@@ -35,6 +36,10 @@ def normalize_settings(config):
     for key in ('extensions', 'ignore_dir'):
         if settings.get(key) is None:
             settings[key] = []
+    # Profiles created before the branch field existed (or with a blank value)
+    # fall back to master so existing configuration keeps working.
+    if not settings.get('branch'):
+        settings['branch'] = 'master'
     return settings
 
 
@@ -82,7 +87,8 @@ def create_profile(profile_name):
         "current_profile": False,
         "extensions": None,
         "ignore_dir": None,
-        "project_dir": None
+        "project_dir": None,
+        "branch": "master"
     })
     json.dump(configs, open(bp + os.sep + 'settings.json', 'w'), indent=4)
     return True
@@ -102,7 +108,7 @@ def change_profile(profile_name):
     return True
 
 
-def update_profile(project_dir, extensions, ignore_dir):
+def update_profile(project_dir, extensions, ignore_dir, branch='master'):
     bp = str(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     configs = json.load(open(bp + os.sep + 'settings.json', 'r'))
     out = []
@@ -111,6 +117,7 @@ def update_profile(project_dir, extensions, ignore_dir):
             config['project_dir'] = project_dir
             config['extensions'] = extensions
             config['ignore_dir'] = ignore_dir
+            config['branch'] = branch or 'master'
         out.append(config)
     json.dump(out, open(bp + os.sep + 'settings.json', 'w'), indent=4)
     return True

--- a/gitnoc/templates/public/settings.html
+++ b/gitnoc/templates/public/settings.html
@@ -38,6 +38,10 @@
             <label for="ignore_dir">Directories to Ignore</label>
             <input name="ignore_dir" id="ignore_dir" value="{{ignore_dir_values}}" />
         </div>
+        <div class="form-group  ">
+            <label for="branch">Branch to Analyze</label>
+            <input name="branch" id="branch" value="{{branch_value}}" />
+        </div>
         <button type="submit" class="btn btn-default" onclick="return confirm('Profile Updated!')">Update Settings</button>
     </form>
 </div>

--- a/gitnoc/views/admin.py
+++ b/gitnoc/views/admin.py
@@ -21,12 +21,13 @@ blueprint = Blueprint('admin', __name__, static_folder="../static")
 def settings():
     form = SettingsForm(request.form, csrf_enabled=False)
     if form.validate_on_submit():
-        settings_services.update_profile(form.project_directory.data, form.extensions.data, form.ignore_dir.data)
+        settings_services.update_profile(form.project_directory.data, form.extensions.data, form.ignore_dir.data, form.branch.data)
 
     settings = settings_services.get_settings()
     extensions = settings.get('extensions', None)
     project_dir = settings.get('project_dir', None)
     ignore_dir = settings.get('ignore_dir', None)
+    branch = settings.get('branch', 'master')
 
     if project_dir is not None:
         if isinstance(project_dir, list):
@@ -52,7 +53,7 @@ def settings():
     else:
         ign = ''
 
-    return render_wrapper('public/settings.html', form=form, project_directory_values=pdv, ignore_dir_values=ign, extensions_values=ext)
+    return render_wrapper('public/settings.html', form=form, project_directory_values=pdv, ignore_dir_values=ign, extensions_values=ext, branch_value=branch or 'master')
 
 
 @blueprint.route('/profile', methods=["GET", "POST"])

--- a/gitnoc/views/metrics.py
+++ b/gitnoc/views/metrics.py
@@ -29,8 +29,9 @@ def punchchard_data():
     project_dir = settings.get('project_dir', os.getcwd())
     extensions = settings.get('extensions', None)
     ignore_dir = settings.get('ignore_dir', None)
+    branch = settings.get('branch', 'master')
 
-    output = get_punchcard(project_dir, extensions, ignore_dir)
+    output = get_punchcard(project_dir, extensions, ignore_dir, branch)
     return str(output)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,16 +12,35 @@ import types
 
 import pytest
 
-# --- Stub the heavy/optional imports pulled in by the settings module --------
+# --- Stub the heavy/optional imports pulled in by the service modules --------
+# CI installs only pytest, so gitpandas / flask-cache / numpy are never present.
+# Stubbing them here lets the pure service logic import and run under pytest.
 if "gitpandas" not in sys.modules:
     _gitpandas_stub = types.ModuleType("gitpandas")
-    _gitpandas_stub.ProjectDirectory = object  # only referenced, never called here
+    _gitpandas_stub.ProjectDirectory = object  # tests monkeypatch the per-module binding
     sys.modules["gitpandas"] = _gitpandas_stub
+
+
+class _DummyCache:
+    """Stand-in for the flask-cache instance; ``cached`` is a no-op decorator."""
+
+    def cached(self, *args, **kwargs):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
 
 if "gitnoc.app" not in sys.modules:
     _app_stub = types.ModuleType("gitnoc.app")
     _app_stub.gp_cache = None
+    _app_stub.cache = _DummyCache()
     sys.modules["gitnoc.app"] = _app_stub
+
+if "numpy" not in sys.modules:
+    _numpy_stub = types.ModuleType("numpy")
+    _numpy_stub.sum = sum  # only used as the aggregator passed to DataFrame.agg
+    sys.modules["numpy"] = _numpy_stub
 
 # Import after stubbing so the real Flask/redis/git-pandas stack is never loaded.
 from gitnoc.services import settings as settings_service  # noqa: E402

--- a/tests/test_service_branch.py
+++ b/tests/test_service_branch.py
@@ -1,0 +1,162 @@
+"""The configured profile branch must reach every branch-aware git-pandas call.
+
+These tests stub ``gitpandas.ProjectDirectory`` with a recorder that captures
+the ``branch`` keyword handed to ``commit_history``, ``punchcard`` and
+``cumulative_blame``, then drive the real service functions and assert the
+active profile's branch (not a hardcoded ``master``) is what git-pandas sees.
+
+The heavy pandas/numpy machinery is stubbed out in ``conftest.py``; the fake
+frames below return just enough surface for each service to run to completion.
+"""
+from gitnoc.services import metrics as metrics_service
+from gitnoc.services import cumulative_blame as cumulative_blame_service
+
+
+# --- minimal DataFrame-ish fakes -------------------------------------------
+
+class _Column:
+    def sum(self):
+        return 0
+
+
+class _Mask:
+    def __invert__(self):
+        return self
+
+
+class _Index:
+    def duplicated(self):
+        return _Mask()
+
+
+class _Values:
+    def tolist(self):
+        return []
+
+
+class FakeFrame:
+    """Enough of the pandas surface for the three services to complete."""
+
+    shape = (0, 0)
+    index = _Index()
+    values = _Values()
+
+    def groupby(self, *args, **kwargs):
+        return self
+
+    def agg(self, *args, **kwargs):
+        return self
+
+    def reset_index(self, *args, **kwargs):
+        return self
+
+    def sort_values(self, *args, **kwargs):
+        return self
+
+    def __getitem__(self, key):
+        # ch['net'] -> a column with .sum(); cb[~mask] -> the frame itself.
+        return _Column() if isinstance(key, str) else self
+
+    def to_json(self, *args, **kwargs):
+        return "{}"
+
+
+def make_recorder():
+    calls = []
+
+    class FakeProjectDirectory:
+        def __init__(self, working_dir=None, cache_backend=None):
+            pass
+
+        def commit_history(self, branch=None, **kwargs):
+            calls.append(("commit_history", branch))
+            return FakeFrame()
+
+        def punchcard(self, branch=None, **kwargs):
+            calls.append(("punchcard", branch))
+            return FakeFrame()
+
+        def cumulative_blame(self, branch=None, **kwargs):
+            calls.append(("cumulative_blame", branch))
+            return FakeFrame()
+
+    return FakeProjectDirectory, calls
+
+
+def branches_for(calls, method):
+    return [branch for name, branch in calls if name == method]
+
+
+def test_week_leader_board_uses_configured_branch(settings_env, monkeypatch):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": True,
+         "project_dir": "/tmp/code", "extensions": ["py"], "ignore_dir": ["vendor"],
+         "branch": "main"},
+    ])
+    fake_pd, calls = make_recorder()
+    monkeypatch.setattr(metrics_service, "ProjectDirectory", fake_pd)
+
+    metrics_service.week_leader_board(n=5)
+
+    # Both the leaderboard call and the per-extension history call use the branch.
+    assert branches_for(calls, "commit_history") == ["main", "main"]
+
+
+def test_punchcard_uses_passed_branch(settings_env, monkeypatch):
+    fake_pd, calls = make_recorder()
+    monkeypatch.setattr(metrics_service, "ProjectDirectory", fake_pd)
+
+    metrics_service.get_punchcard("/tmp/code", ["py"], ["vendor"], branch="develop")
+
+    assert branches_for(calls, "punchcard") == ["develop"]
+
+
+def test_punchcard_defaults_to_master(settings_env, monkeypatch):
+    fake_pd, calls = make_recorder()
+    monkeypatch.setattr(metrics_service, "ProjectDirectory", fake_pd)
+
+    metrics_service.get_punchcard("/tmp/code", ["py"], ["vendor"])
+
+    assert branches_for(calls, "punchcard") == ["master"]
+
+
+def _redirect_blame_output(cumulative_module, base_dir, monkeypatch):
+    """Point the service's ``__file__`` (and thus its output dir) into tmp_path.
+
+    ``cumulative_blame`` derives its output directory from its own ``__file__``
+    and writes ``<dir>/static/data/<file>``; the ``open(...)`` argument creates
+    that file even if ``json.dump`` is a no-op, so we redirect the whole tree
+    into the throwaway temp dir instead of polluting the repo.
+    """
+    fake_file = base_dir / "gitnoc" / "services" / "cumulative_blame.py"
+    (base_dir / "gitnoc" / "static" / "data").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cumulative_module, "__file__", str(fake_file))
+
+
+def test_cumulative_blame_uses_configured_branch(settings_env, tmp_path, monkeypatch):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": True,
+         "project_dir": "/tmp/code", "extensions": ["py"], "ignore_dir": ["vendor"],
+         "branch": "main"},
+    ])
+    fake_pd, calls = make_recorder()
+    monkeypatch.setattr(cumulative_blame_service, "ProjectDirectory", fake_pd)
+    _redirect_blame_output(cumulative_blame_service, tmp_path, monkeypatch)
+
+    cumulative_blame_service.cumulative_blame("committer", "cumulative_author_blame.json")
+
+    assert branches_for(calls, "cumulative_blame") == ["main"]
+
+
+def test_cumulative_blame_missing_branch_falls_back_to_master(settings_env, tmp_path, monkeypatch):
+    settings_env.write([
+        {"profile_name": "legacy", "current_profile": True,
+         "project_dir": "/tmp/code", "extensions": ["py"], "ignore_dir": ["vendor"]},
+    ])
+    fake_pd, calls = make_recorder()
+    monkeypatch.setattr(cumulative_blame_service, "ProjectDirectory", fake_pd)
+    _redirect_blame_output(cumulative_blame_service, tmp_path, monkeypatch)
+
+    cumulative_blame_service.cumulative_blame("committer", "cumulative_author_blame.json")
+
+    assert branches_for(calls, "cumulative_blame") == ["master"]

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -6,16 +6,16 @@ temporary ``settings.json`` so the repo's real config is never read or written.
 """
 
 
-def test_get_settings_missing_file_returns_empty_default(settings_env):
-    # No settings.json on disk at all -> safe empty default, not an exception.
+def test_get_settings_missing_file_returns_default_profile(settings_env):
+    # No settings.json on disk at all -> synthetic default, not an exception.
     assert not settings_env.path.exists()
-    assert settings_env.module.get_settings() == {}
+    assert settings_env.module.get_settings() == settings_env.module.default_settings()
 
 
-def test_get_settings_empty_file_returns_empty_default(settings_env):
-    # An empty/malformed file is swallowed and yields the empty default.
+def test_get_settings_empty_file_returns_default_profile(settings_env):
+    # An empty/malformed file is swallowed and yields the synthetic default.
     settings_env.path.write_text("")
-    assert settings_env.module.get_settings() == {}
+    assert settings_env.module.get_settings() == settings_env.module.default_settings()
 
 
 def test_get_settings_returns_current_profile(settings_env):
@@ -26,9 +26,9 @@ def test_get_settings_returns_current_profile(settings_env):
     assert settings_env.module.get_settings()["profile_name"] == "b"
 
 
-def test_get_settings_no_current_profile_returns_empty(settings_env):
+def test_get_settings_no_current_profile_returns_default(settings_env):
     settings_env.write([{"profile_name": "a", "current_profile": False}])
-    assert settings_env.module.get_settings() == {}
+    assert settings_env.module.get_settings() == settings_env.module.default_settings()
 
 
 def test_create_profile_appends(settings_env):
@@ -45,6 +45,8 @@ def test_create_profile_appends(settings_env):
         assert c["extensions"] is None
         assert c["ignore_dir"] is None
         assert c["project_dir"] is None
+        # A backward-compatible default branch is persisted on creation.
+        assert c["branch"] == "master"
 
 
 def test_change_profile_sets_exactly_one_current(settings_env):
@@ -123,3 +125,47 @@ def test_ignore_file_appends_to_current_profile(settings_env):
     # Dashes in the encoded path are turned back into path separators.
     assert by_name["b"]["ignore_dir"] == ["src/vendor/lib"]
     assert by_name["a"]["ignore_dir"] == []
+
+
+# --- branch selection -------------------------------------------------------
+
+def test_get_settings_missing_branch_normalizes_to_master(settings_env):
+    # Profiles created before the branch field existed have no branch key.
+    settings_env.write([{"profile_name": "legacy", "current_profile": True}])
+    assert settings_env.module.get_settings()["branch"] == "master"
+
+
+def test_get_settings_blank_branch_normalizes_to_master(settings_env):
+    settings_env.write([{"profile_name": "a", "current_profile": True, "branch": ""}])
+    assert settings_env.module.get_settings()["branch"] == "master"
+
+
+def test_get_settings_returns_configured_branch(settings_env):
+    settings_env.write([{"profile_name": "a", "current_profile": True, "branch": "main"}])
+    assert settings_env.module.get_settings()["branch"] == "main"
+
+
+def test_update_profile_persists_branch(settings_env):
+    settings_env.write([
+        {"profile_name": "b", "current_profile": True,
+         "project_dir": None, "extensions": None, "ignore_dir": None, "branch": "master"},
+    ])
+
+    assert settings_env.module.update_profile(
+        project_dir="/tmp/code", extensions=["py"], ignore_dir=["vendor"], branch="main"
+    ) is True
+
+    assert settings_env.read()[0]["branch"] == "main"
+
+
+def test_update_profile_blank_branch_defaults_to_master(settings_env):
+    settings_env.write([
+        {"profile_name": "b", "current_profile": True,
+         "project_dir": None, "extensions": None, "ignore_dir": None, "branch": "main"},
+    ])
+
+    settings_env.module.update_profile(
+        project_dir="/tmp/code", extensions=None, ignore_dir=None, branch=""
+    )
+
+    assert settings_env.read()[0]["branch"] == "master"


### PR DESCRIPTION
Closes #12

## What changed
GitNOC hardcoded `branch='master'` in every branch-aware analytics call, so repositories whose analyzed branch is `main` (or anything else) could not produce the leaderboard, punchcard, or cumulative-blame data. This adds an optional per-profile `branch` field and threads the normalized value through the services.

- **Settings service** (`services/settings.py`): `default_settings()` and `normalize_settings()` now supply/normalize a `branch` key — a missing or blank value falls back to `master`, so profiles created before this field existed keep working. `create_profile()` seeds `"branch": "master"`, and `update_profile()` gained a `branch` param that persists the selection (blank → `master`).
- **Form / view / template**: `SettingsForm` gains a `branch` field (blank normalizes to `master`); `admin.settings` passes it to `update_profile` and renders the current value; `settings.html` exposes a "Branch to Analyze" input.
- **Services**: `week_leader_board` (both `commit_history` calls), `get_punchcard`, and `cumulative_blame` now read the active profile's branch instead of the hardcoded literal. `get_punchcard` takes a `branch` arg (default `master`); the metrics view passes the profile's branch.

### Incidental cleanups (on touched lines only)
- Removed the leftover debug `print()` calls in `metrics.week_leader_board` and `cumulative_blame` — they sat on the exact lines being edited and would otherwise print stub `Mock` reprs during the new tests.
- Updated three stale settings tests that still asserted the old `get_settings() == {}` return. That behavior was replaced by `default_settings()` in a prior change, so those three were **already red on `master`** (3 failed / 10 passed); they now assert the current default-profile shape (including `branch`), making the suite green.

## Testing
- New `tests/test_service_branch.py` stubs `gitpandas.ProjectDirectory` with a recorder and drives the real service functions, asserting the configured branch reaches `commit_history`, `punchcard`, and `cumulative_blame` (and that a profile with no `branch` key falls back to `master`).
- Extended `tests/test_settings_service.py` for branch normalization on read, creation seeding, and update persistence.
- `conftest.py` gained lightweight `cache`/`numpy` stubs so the metrics/blame modules import under the pytest-only CI (no gitpandas/numpy/flask installed).

Test suite is decoupled from the runtime stack via `sys.modules` stubs, matching the repo's existing convention.

## Verification
- `uv run --with 'pytest>=7' pytest -q` -> **23 passed** (was 10 passed / 3 failed on `master`).
- Non-vacuous check: reverted each service call site to a hardcoded `branch="MUT_master"` and confirmed all 5 branch tests in `test_service_branch.py` fail, then restored — the tests genuinely guard the configured branch reaching git-pandas.