### PR TITLE
Rank each extension from its own commit history

### DIFF
--- a/gitnoc/services/metrics.py
+++ b/gitnoc/services/metrics.py
@@ -39,7 +39,7 @@ def week_leader_board(n=5):
     if extensions is not None:
         ext_ranks = []
         for ext in extensions:
-            ch = repo.commit_history(branch=branch, ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (x, ) for x in extensions], days=21)
+            ch = repo.commit_history(branch=branch, ignore_globs=['*/%s/*' % (x, ) for x in ignore_dir], include_globs=['*.%s' % (ext, )], days=21)
             ext_ranks.append((ch[metric].sum(), ext))
         ext_ranks = sorted(ext_ranks, key=lambda x: x[0], reverse=True)[:n]
         leader_board['top_extensions'] = [{'label': x[1], 'net': int(x[0]), 'rank': idx + 1} for idx, x in enumerate(ext_ranks)]

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -1,0 +1,92 @@
+from gitnoc.services import metrics as metrics_service
+
+
+class _Values:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def tolist(self):
+        return self.rows
+
+
+class _GroupedFrame:
+    def __init__(self, rows):
+        self.values = _Values(rows)
+
+    def agg(self, *args, **kwargs):
+        return self
+
+    def reset_index(self, *args, **kwargs):
+        return self
+
+    def sort_values(self, *args, **kwargs):
+        self.values.rows.sort(key=lambda row: row[1], reverse=True)
+        return self
+
+
+class _NetColumn:
+    def __init__(self, total):
+        self.total = total
+
+    def sum(self):
+        return self.total
+
+
+class _HistoryFrame:
+    def __init__(self, net, grouped=None):
+        self.net = net
+        self.grouped = grouped or {}
+
+    def groupby(self, columns):
+        return _GroupedFrame(list(self.grouped[columns[0]]))
+
+    def __getitem__(self, key):
+        assert key == "net"
+        return _NetColumn(self.net)
+
+
+def test_week_leader_board_ranks_each_extension_from_its_own_history(settings_env, monkeypatch):
+    settings_env.write([
+        {"profile_name": "a", "current_profile": True,
+         "project_dir": "/tmp/code", "extensions": ["py", "js"],
+         "ignore_dir": ["vendor"], "branch": "main"},
+    ])
+    calls = []
+
+    class FakeProjectDirectory:
+        def __init__(self, working_dir=None, cache_backend=None):
+            pass
+
+        def commit_history(self, **kwargs):
+            calls.append(kwargs)
+            include_globs = kwargs["include_globs"]
+            if include_globs == ["*.py", "*.js"]:
+                return _HistoryFrame(12, {
+                    "committer": [("alice", 8), ("bob", 4)],
+                    "repository": [("api", 9), ("web", 3)],
+                })
+            return _HistoryFrame({("*.py",): 5, ("*.js",): 7}[tuple(include_globs)])
+
+    monkeypatch.setattr(metrics_service, "ProjectDirectory", FakeProjectDirectory)
+
+    result = metrics_service.week_leader_board(n=5)
+
+    assert [call["include_globs"] for call in calls] == [
+        ["*.py", "*.js"],
+        ["*.py"],
+        ["*.js"],
+    ]
+    assert result == {
+        "top_committers": [
+            {"label": "alice", "net": 8, "rank": 1},
+            {"label": "bob", "net": 4, "rank": 2},
+        ],
+        "top_repositories": [
+            {"label": "api", "net": 9, "rank": 1},
+            {"label": "web", "net": 3, "rank": 2},
+        ],
+        "top_extensions": [
+            {"label": "js", "net": 7, "rank": 1},
+            {"label": "py", "net": 5, "rank": 2},
+        ],
+    }


### PR DESCRIPTION
Closes #11

## Summary

- isolate each extension leaderboard query to the extension currently being ranked
- add a focused regression test around `week_leader_board()` that records git-pandas globs and asserts value-based committer, repository, and extension rankings

## Verification

- `uv run --with 'pytest>=7' pytest` — 24 passed
- `git diff --check` — passed
- Mutation check: temporarily restored the full-extension-list bug and ran `uv run --with 'pytest>=7' pytest tests/test_metrics_service.py`; the new regression test failed on the per-extension glob assertion, then passed after restoring the fix.
