### PR TITLE
Align settings tests with safe defaults

### DIFF
--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -5,17 +5,27 @@ These exercise the file-backed JSON profile logic in isolation.  The
 temporary ``settings.json`` so the repo's real config is never read or written.
 """
 
+import os
+
+
+def assert_safe_defaults(settings):
+    assert settings["profile_name"] == "default"
+    assert settings["project_dir"] == os.getcwd()
+    assert settings["extensions"] == []
+    assert settings["ignore_dir"] == []
+    assert settings["branch"] == "master"
+
 
 def test_get_settings_missing_file_returns_default_profile(settings_env):
     # No settings.json on disk at all -> synthetic default, not an exception.
     assert not settings_env.path.exists()
-    assert settings_env.module.get_settings() == settings_env.module.default_settings()
+    assert_safe_defaults(settings_env.module.get_settings())
 
 
 def test_get_settings_empty_file_returns_default_profile(settings_env):
     # An empty/malformed file is swallowed and yields the synthetic default.
     settings_env.path.write_text("")
-    assert settings_env.module.get_settings() == settings_env.module.default_settings()
+    assert_safe_defaults(settings_env.module.get_settings())
 
 
 def test_get_settings_returns_current_profile(settings_env):
@@ -28,7 +38,7 @@ def test_get_settings_returns_current_profile(settings_env):
 
 def test_get_settings_no_current_profile_returns_default(settings_env):
     settings_env.write([{"profile_name": "a", "current_profile": False}])
-    assert settings_env.module.get_settings() == settings_env.module.default_settings()
+    assert_safe_defaults(settings_env.module.get_settings())
 
 
 def test_create_profile_appends(settings_env):


### PR DESCRIPTION
Closes #9

## Summary
- assert the safe fallback values directly for missing, malformed, and no-current-profile settings
- compare `project_dir` with the current working directory instead of a machine-specific path
- retain the current `branch` safe default introduced on master
- leave production code unchanged

## Verification
- `uv run --with 'pytest>=7' pytest` — 23 passed\n- mutation check: temporarily changed the default profile name and ran the three fallback tests — all three failed; restored production code and confirmed its diff is clean\n- `git diff --check` — passed